### PR TITLE
Nfspolicy rename fixes

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
@@ -661,6 +661,7 @@ def rename_nfs_policy(module, blade):
                     res.errors[0].message,
                 )
             )
+        module.exit_json(changed=changed)
 
 
 def update_nfs_policy(module, blade):
@@ -1691,7 +1692,7 @@ def main():
                 )[0]
             except AttributeError:
                 new_policy = None
-        if policy and state == "present":
+        if policy and state == "present" and "rename" not in module.params:
             if module.params["before_rule"]:
                 res = blade.get_nfs_export_policies_rules(
                     policy_names=[module.params["name"]],
@@ -1710,7 +1711,7 @@ def main():
             state == "present" and module.params["rename"] and policy and not new_policy
         ):
             rename_nfs_policy(module, blade)
-        elif state == "present" and not policy:
+        elif state == "present" and not policy and "rename" not in module.params:
             create_nfs_policy(module, blade)
         elif state == "absent" and policy:
             delete_nfs_policy(module, blade)

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
@@ -1692,7 +1692,7 @@ def main():
                 )[0]
             except AttributeError:
                 new_policy = None
-        if policy and state == "present" and "rename" not in module.params:
+        if policy and state == "present" and not module.params["rename"]
             if module.params["before_rule"]:
                 res = blade.get_nfs_export_policies_rules(
                     policy_names=[module.params["name"]],
@@ -1711,7 +1711,7 @@ def main():
             state == "present" and module.params["rename"] and policy and not new_policy
         ):
             rename_nfs_policy(module, blade)
-        elif state == "present" and not policy and "rename" not in module.params:
+        elif state == "present" and not policy and not module.params["rename"]:
             create_nfs_policy(module, blade)
         elif state == "absent" and policy:
             delete_nfs_policy(module, blade)

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
@@ -1692,7 +1692,7 @@ def main():
                 )[0]
             except AttributeError:
                 new_policy = None
-        if policy and state == "present" and not module.params["rename"]
+        if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
                 res = blade.get_nfs_export_policies_rules(
                     policy_names=[module.params["name"]],


### PR DESCRIPTION
SUMMARY
Add support to allow NFS Export Policy rename from REST 2.4

ISSUE TYPE
Feature Pull Request
COMPONENT NAME
purefb_policy.py

ADDITIONAL INFORMATION
Requires a minimum of Purity//FB 3.3.3